### PR TITLE
Force strict mode in Node.js

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -216,7 +216,7 @@ def nodejs(bot, target, nick, command, text):
 	cmd = ['../nsjail/nsjail', '-Mo', '--rlimit_as', '700', '--chroot', 'chroot',
 			'-R/usr', '-R/lib', '-R/lib64', '--user', 'nobody', '--group', 'nogroup',
 			'--time_limit', '2', '--disable_proc', '--iface_no_lo', '--',
-			'/usr/bin/nodejs', '--print', text]
+			'/usr/bin/nodejs', '--use_strict', '--print', text]
 	proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
 			stderr=subprocess.PIPE, universal_newlines=True)
 	stdout, stderr = proc.communicate()


### PR DESCRIPTION
Allows user to use block-scoped declarations without having to declare `'use strict';` every line. See [here](https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md#use_strict-false-boolean) for more info.

**TAG: Technical Debt**
